### PR TITLE
Add #define's and #cmakedefine's to config.h.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
 endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+# Values of properties will be forwarded into the config.h
 set(DATABASE "DB2" CACHE STRING "Command language dialect to target with the qgen query generator (\"DATABASE\"")
 set_property(CACHE DATABASE PROPERTY STRINGS INFORMIX DB2 TDAT SQLSERVER SYBASE ORACLE VECTORWISE POSTGRES)
 
@@ -64,8 +65,6 @@ add_executable(qgen
 	src/text.c
 	src/varsub.c
 )
-
-set_property(TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS ${DATABASE} ${WORKLOAD})
 
 set_property(TARGET dbgen qgen APPEND PROPERTY C_STANDARD 99)
 set_property(TARGET dbgen qgen APPEND PROPERTY C_EXTENSIONS OFF)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -36,6 +36,10 @@
  *   TPCH              -- make will create TPCH (set in makefile)
  */
 
+#define @DATABASE@
+#define @WORKLOAD@
+#cmakedefine EOL_HANDLING
+
 #cmakedefine HAVE_INTTYPES_H
 #cmakedefine HAVE_STDINT_H
 #cmakedefine HAVE_SYS_BITTYPES_H

--- a/src/dss.h
+++ b/src/dss.h
@@ -2,6 +2,13 @@
  * general definitions and control information for the DSS code 
  * generator; if it controls the data set, it's here
  */
+
+#include "config.h"
+#include "shared.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
 #ifndef DSS_H
 #define  DSS_H
 #ifdef TPCH
@@ -15,12 +22,6 @@
 #endif
 #define TPC             "Transaction Processing Performance Council"
 #define C_DATES         "1994 - 2010"
-
-#include "config.h"
-#include "shared.h"
-
-#include <stdio.h>
-#include <stdlib.h>
 
 #define  NONE		-1
 #define  PART		0

--- a/src/tpcd.h
+++ b/src/tpcd.h
@@ -26,6 +26,8 @@
 #define QDIR_TAG        "DSS_QUERY"  /* variable to point to queries */
 #define QDIR_DFLT       "queries"    /* and its default */
 
+#include "config.h"
+
 /*
  * database portability defines
  */


### PR DESCRIPTION
Add missed `#cmakedefine` for `EOL_HANDLING`, move macros definition for `DATABASE` and  `WORKLOAD` to src/config.h.in and force config.h inclusion at the beginning of files where they are mentioned.